### PR TITLE
reverted the pexepct back to its origional syncerate run commands, bu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Syncerate processes each matching source and destination ZFS dataset pair listed in two text files. Dataset pairs run sequentially, and optional retry handling can repeat an individual pair when a Broken Pipe occurs.
 
-Current version: `0.4.20`
+Current version: `0.4.21`
 
 ## Disclaimer and liability notice
 
@@ -326,24 +326,27 @@ The `SyncoidCommand` must contain the identity explicitly, for example:
 SyncoidCommand = syncoid backupuser@192.0.2.10:SourceDataSet DestDataSet --sshkey /root/.ssh/syncerate --no-privilege-elevation
 ```
 
-When enabled, Syncerate does not try to type the key passphrase through the nested `Syncoid -> ssh` terminal path. Instead it:
+Private-agent mode now preserves the original Syncerate process model: **Pexpect starts Syncoid, and Syncoid remains responsible for starting and controlling SSH, mbuffer, pv, ZFS send/receive, and its own SSH control connections.** Syncerate does not replace Syncoid's SSH process and does not rewrite the configured Syncoid command with hidden SSH options.
+
+When enabled, Syncerate:
 
 1. creates a random per-run temporary directory with mode `0700`;
 2. starts a new foreground `ssh-agent` bound to a socket inside that directory;
 3. ignores any pre-existing `SSH_AUTH_SOCK` / `SSH_AGENT_PID`;
 4. removes inherited `SSH_ASKPASS` use for the private-agent path;
-5. runs `ssh-add` under Pexpect directly and sends the passphrase only to that direct prompt;
-6. loads only the configured `--sshkey` identity with the configured bounded lifetime;
-7. gives Syncoid only this private agent;
-8. forces Syncoid SSH options `ForwardAgent=no`, `StrictHostKeyChecking=yes`, `IdentitiesOnly=yes`, `AddKeysToAgent=no`, `BatchMode=yes`, `PreferredAuthentications=publickey`, and the exact private `IdentityAgent` socket;
-9. checks that the agent still contains an identity before each dataset and reloads it if the configured lifetime expired;
-10. removes all agent identities, terminates the agent, and removes its temporary socket directory when the run exits normally or raises an application error.
+5. runs `ssh-add` under Pexpect directly and sends the configured key passphrase to that direct prompt;
+6. loads the identity selected by the existing `--sshkey` option with the configured bounded lifetime;
+7. exposes the isolated agent to Syncoid only through the child environment (`SSH_AUTH_SOCK` / `SSH_AGENT_PID`);
+8. starts the **original configured Syncoid argv under Pexpect unchanged**; Syncoid then creates SSH/mbuffer/ZFS processes exactly as it normally does;
+9. keeps the original Pexpect-through-Syncoid password/passphrase prompt handling available if Syncoid's nested SSH still asks interactively;
+10. checks that the agent still contains an identity before each dataset and reloads it if the configured lifetime expired;
+11. removes agent identities, terminates the agent, and removes its temporary socket directory when the run exits normally or raises an application error.
 
 The one-hour default limits the usefulness of an orphaned agent if the Python process is terminated in a way that prevents cleanup. A transfer already authenticated through Syncoid's SSH control connection can continue if the identity lifetime expires; Syncerate reloads the key before the next dataset.
 
-Because private-agent mode forces `BatchMode=yes`, public-key-only authentication, and `StrictHostKeyChecking=yes`, it intentionally does **not** fall back to an SSH account password or automatically trust a new/changed host key. The remote host key must already be present in the executing user's `known_hosts`; verify it once with normal `ssh` before using private-agent mode.
+Unlike the earlier private-agent implementation, Syncerate no longer prepends `ForwardAgent`, `StrictHostKeyChecking`, `IdentitiesOnly`, `IdentityAgent`, `AddKeysToAgent`, `BatchMode`, or `PreferredAuthentications` settings to the Syncoid command. SSH behavior therefore comes from the configured `SyncoidCommand`, Syncoid itself, and the executing user's normal SSH configuration. Existing `.cfg` files do not need any changes for this release.
 
-Agent forwarding is explicitly disabled. This is important because a forwarded agent can otherwise allow a compromised remote host to request authentication operations from identities held by the local agent. The private key and passphrase are not intentionally written to Syncerate logs.
+The private agent is still isolated and contains only the configured Syncerate identity. If your own SSH configuration enables agent forwarding, that policy is no longer overridden by Syncerate; disable forwarding in your SSH/Syncoid configuration if you do not want the agent exposed to a remote host.
 
 ### Legacy authentication mode
 
@@ -353,7 +356,7 @@ With:
 UseSSHAgent = No
 ```
 
-Syncerate preserves the existing Pexpect-through-Syncoid behavior. If Syncoid/SSH produces an account-password or private-key-passphrase prompt, Syncerate waits up to 3 seconds for no-echo mode and sends `PassWord`. If `PassWord = No`, an observed credential prompt is treated as an authentication error.
+Syncerate uses the original Pexpect-through-Syncoid model. Pexpect starts Syncoid and watches the output produced by Syncoid and its nested SSH process. If an SSH account-password or private-key-passphrase prompt appears, Syncerate temporarily disables the `.out` logfile, sends `PassWord` directly to the Syncoid Pexpect child with `child.sendline()`, then restores logging. It does not wait for a separate no-echo transition before sending. If `PassWord = No`, an observed credential prompt remains a fatal authentication error.
 
 ## Logging
 

--- a/Syncerate.py
+++ b/Syncerate.py
@@ -67,7 +67,6 @@ from syncerate.syncoid_runner import (
     effective_user_name,
     ensure_private_agent_identity,
     extract_ssh_key_path,
-    harden_syncoid_command_for_agent,
     log_command_debug,
     private_agent_has_identity,
     private_ssh_agent,

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -16,6 +16,22 @@ The patch number rolls over as follows:
 
 It must never become `0.0.100`.
 
+## 0.4.21
+
+Previous version: `0.4.20`.
+
+- Restored the original Pexpect/Syncoid execution ownership: Pexpect starts and monitors Syncoid, while Syncoid remains responsible for creating and controlling SSH, mbuffer, pv, ZFS send/receive, and its own SSH control connections.
+- Private `ssh-agent` / `ssh-add` support is preserved. Syncerate still starts one isolated per-run agent, loads the existing `SyncoidCommand --sshkey` with direct Pexpect control of `ssh-add`, refreshes the key after its configured lifetime when needed, and cleans up the agent at the end of the run.
+- Removed Syncerate's private-agent Syncoid command hardening layer. Agent mode no longer prepends `ForwardAgent=no`, `StrictHostKeyChecking=yes`, `IdentitiesOnly=yes`, `IdentityAgent=...`, `AddKeysToAgent=no`, `BatchMode=yes`, or `PreferredAuthentications=publickey` to the configured command.
+- Agent mode now exposes the isolated agent only through the child environment (`SSH_AUTH_SOCK` / `SSH_AGENT_PID`) and executes the same Syncoid argv that would be used without the agent.
+- Restored original nested credential handling for the Syncoid Pexpect child: account-password and key-passphrase prompts temporarily disable `.out` logging, use direct `child.sendline(password)`, and restore logging without the newer `waitnoecho()` step.
+- Retained `send_secret()` and its no-echo handling for the **direct Pexpect -> ssh-add** interaction only.
+- `PassWord` is again passed to the Pexpect-through-Syncoid monitor even when the private agent is enabled, preserving the original fallback prompt behavior if Syncoid's nested SSH asks interactively.
+- Preserved 0.4.18 stale receive-state recovery, including allowing Syncoid to reset its own invalid resumable receive stream and the associated Broken Pipe recovery-state handling.
+- Preserved configurable ordinary Broken Pipe retries, JSON MQTT success/failure reporting, legacy retained MQTT, legacy Home Assistant availability publishing, email, system actions, dataset validation, and current exit-code handling.
+- No configuration option was added, removed, renamed, or given a new required value. Existing 0.4.20 `.cfg` files are valid unchanged.
+- Updated `README.md`, `commented_code_map.md`, example comments, and version metadata for the restored execution model.
+
 ## 0.4.20
 
 Previous version: `0.4.19`.

--- a/commented_code_map.md
+++ b/commented_code_map.md
@@ -1,6 +1,6 @@
 # Syncerate commented code map
 
-This document maps the modular Syncerate implementation in version `0.4.20`. It explains what every module, class, function, command stage, and safety branch does and why it exists.
+This document maps the modular Syncerate implementation in version `0.4.21`. It explains what every module, class, function, command stage, and safety branch does and why it exists.
 
 ## Application layout
 
@@ -71,7 +71,7 @@ Keeping `sys.exit()` at this boundary means internal modules return values or ra
 ### `VERSION` and `__version__`
 
 ```python
-VERSION = "0.4.20"
+VERSION = "0.4.21"
 __version__ = VERSION
 ```
 
@@ -472,9 +472,9 @@ Converts optional `pexpect` values into safe strings. `None` becomes an empty st
 
 ### `send_secret(child, password, output_handle, logging_enabled)`
 
-Handles both SSH account-password prompts and encrypted private-key passphrase prompts through one credential-send path. It temporarily disables the Pexpect logfile, waits up to 3 seconds with `child.waitnoecho(timeout=3)` for the pseudo-terminal to enter no-echo mode, sends the secret with `child.sendline()`, and restores the original output logfile in a `finally` block.
+Used for a **directly controlled interactive child**, currently `ssh-add` in private-agent mode. It temporarily disables any Pexpect logfile, waits up to 3 seconds for no-echo input, sends the secret with `child.sendline()`, and restores logging in `finally`.
 
-The wait reduces the risk of sending a credential before newer OpenSSH versions have completed their TTY transition. If no-echo is not observed within 3 seconds, Pexpect returns `False` and Syncerate still sends the credential, preserving the previous behavior as a fallback. The `finally` block restores logging even if waiting or sending raises an exception.
+The main Syncoid runner deliberately does **not** use this helper in 0.4.21. Its password/passphrase branches are restored to the original Pexpect-through-Syncoid behavior and call `child.sendline(password)` directly after temporarily disabling the `.out` logfile.
 
 ### `extract_ssh_key_path(command_template)`
 
@@ -508,21 +508,6 @@ Checks that the private agent process is alive and runs `ssh-add -l` against onl
 
 Runs before each dataset when agent mode is enabled. If the isolated agent became empty because the configured lifetime expired, it reloads the same identity using direct Pexpect/`ssh-add`. An already-authenticated Syncoid SSH control connection does not need the key to remain loaded, so refresh is only needed before starting the next dataset.
 
-### `harden_syncoid_command_for_agent(syncoid_command, session)`
-
-Prepends Syncoid `--sshoption` values so they become the first command-line values OpenSSH receives:
-
-```text
-ForwardAgent=no
-StrictHostKeyChecking=yes
-IdentitiesOnly=yes
-IdentityAgent=<private socket>
-AddKeysToAgent=no
-BatchMode=yes
-PreferredAuthentications=publickey
-```
-
-These options make private-agent mode deterministic: Syncoid must use only the selected key from Syncerate's isolated agent, cannot forward the agent to the remote host, cannot add more keys, cannot fall back to interactive account-password/passphrase prompts, and cannot automatically accept a new or changed host key. The intended remote host key must already be trusted in the executing user's `known_hosts`.
 
 ### `stop_private_ssh_agent(session, logger)`
 
@@ -583,7 +568,7 @@ Starts one process with:
 pexpect.spawn(command[0], command[1:], timeout=None, encoding="utf-8", env=process_env)
 ```
 
-Using an argv list avoids shell re-parsing. `process_env` is normally `None`; private-agent mode passes only the isolated agent environment to Syncoid and its nested SSH children.
+Using an argv list avoids shell re-parsing. `process_env` is normally `None`; private-agent mode passes the isolated agent environment to the **same Syncoid command**, so Syncoid and the SSH processes it creates inherit `SSH_AUTH_SOCK`. Pexpect still owns Syncoid, not SSH or mbuffer directly.
 
 It monitors these conditions:
 
@@ -592,7 +577,7 @@ It monitors these conditions:
 3. **Permission denied** — exits through code `5`.
 4. **Connection timeout** — code `6`.
 5. **Connection refused** — code `7`.
-6. **Passphrase prompt** — uses `send_secret()` to wait up to 3 seconds for no-echo mode, send the configured credential without logging it, and restore logging.
+6. **Passphrase prompt** — restores the original runner behavior: temporarily disables `.out` logging, sends `PassWord` directly to the Pexpect-controlled Syncoid PTY with `child.sendline()`, then restores logging.
 7. **EOF** — returns the real child and current result flags.
 8. **Skipped dataset warning** — code `8`.
 9. **Missing stale-resume source snapshot** — marks Syncoid stale-receive recovery active, logs that Syncoid will be allowed to repair its own receive state, and keeps the same process running. Syncerate does not alter the Syncoid command.
@@ -601,7 +586,7 @@ It monitors these conditions:
 12. **Resume feature unavailable** — logs the exact nonfatal message and waits for Syncoid's real exit status.
 13. **Broken Pipe** — during stale receive recovery it is logged and ignored as an expected symptom of the failed resume pipeline; otherwise, when `RetryBrokenPipe` is enabled, it terminates the current attempt and returns `broken_pipe_detected=True`, and when disabled it waits for the real child exit status.
 14. **Generic warning** — remains fatal with code `4`, except the separately recognized destroy warning and stale-receive reset warning.
-15. **Password prompt** — uses the same `send_secret()` path as a private-key passphrase.
+15. **Password prompt** — uses the same original direct `child.sendline()` path through the Pexpect-controlled Syncoid PTY.
 
 Each pattern is limited to five matches. Exceeding the limit sets `repeated_pattern` so the caller can fail safely with code `9`.
 
@@ -613,10 +598,10 @@ Runs all validated pairs sequentially.
 
 For each pair it:
 
-1. builds the command;
-2. when private-agent mode is active, verifies/reloads the one agent identity and prepends the SSH hardening options;
+1. builds the command exactly from `SyncoidCommand`, the dataset pair, and per-destination arguments;
+2. when private-agent mode is active, verifies/reloads the one agent identity but **does not modify the Syncoid argv**;
 3. logs extra arguments and argv details;
-4. starts `ssh_command()` with the isolated agent environment and no nested-Syncoid credential sending in agent mode;
+4. starts `ssh_command()` with Pexpect controlling Syncoid in both agent and non-agent modes; agent mode only adds the isolated `SSH_AUTH_SOCK` environment and still passes `PassWord` to the original nested-prompt handler;
 5. leaves stale interrupted-receive recovery inside the same Syncoid process instead of constructing a second resume-bypass command;
 6. when enabled, gives each dataset its own `app_config.broken_pipe_retry_count` allowance and waits `app_config.broken_pipe_retry_wait_seconds` before every ordinary Broken Pipe retry;
 7. records and skips only that pair after its configured ordinary Broken Pipe retry allowance is exhausted;

--- a/config/example-Syncerate.cfg
+++ b/config/example-Syncerate.cfg
@@ -1,4 +1,4 @@
-# Syncerate 0.4.20 example configuration.
+# Syncerate 0.4.21 example configuration.
 # Copy this file, edit the paths and command, then run:
 #   ./Syncerate.py --conf /path/to/Syncerate.cfg
 
@@ -26,18 +26,18 @@ SyncoidCommand = syncoid username@192.0.2.10:SourceDataSet DestDataSet --compres
 #   No   = do not provide a password or passphrase
 #   Ask  = prompt securely when Syncerate starts (recommended for encrypted keys)
 #   text = use the literal value from this file
-# Legacy mode (UseSSHAgent = No) sends this through Pexpect when Syncoid/SSH
-# prompts. Private-agent mode sends it only to ssh-add before Syncoid starts.
+# Pexpect-through-Syncoid mode sends this when nested SSH prompts. In agent
+# mode it is first used by ssh-add and remains available to the original
+# Pexpect-through-Syncoid prompt handling if nested SSH still asks.
 PassWord = No
 
-# Optional safest key-passphrase mode for Syncoid SSH:
-#   No  = preserve legacy direct Pexpect-through-Syncoid credential handling
-#   Yes = start one isolated per-run ssh-agent, load the --sshkey identity with
-#         direct Pexpect -> ssh-add, and force Syncoid SSH to use only that key.
+# Optional private ssh-agent for encrypted --sshkey identities:
+#   No  = original Pexpect -> Syncoid behavior with no private agent
+#   Yes = start one isolated per-run ssh-agent and load the --sshkey identity
+#         with direct Pexpect -> ssh-add before Pexpect starts Syncoid.
+# SyncoidCommand is not rewritten; Syncoid still controls SSH/mbuffer/ZFS and
+# inherits the private agent through SSH_AUTH_SOCK.
 # Requires --sshkey in SyncoidCommand plus ssh-agent and ssh-add from OpenSSH.
-# Agent forwarding is forced off; BatchMode/public-key-only authentication and
-# StrictHostKeyChecking=yes are forced on. The remote host key must already exist
-# in the executing user's known_hosts.
 UseSSHAgent = No
 
 # Maximum lifetime of the loaded agent identity, in seconds. Must be > 0.

--- a/syncerate/__init__.py
+++ b/syncerate/__init__.py
@@ -4,7 +4,7 @@ Importing this package does not parse arguments, read configuration, create
 logs, request credentials, or start Syncoid.
 """
 
-VERSION = "0.4.20"
+VERSION = "0.4.21"
 __version__ = VERSION
 
 __all__ = ["VERSION", "__version__"]

--- a/syncerate/syncoid_runner.py
+++ b/syncerate/syncoid_runner.py
@@ -80,7 +80,7 @@ def send_secret(
     output_handle: Any,
     logging_enabled: bool,
 ) -> None:
-    """Wait for no-echo credential input, send the secret, and restore logging."""
+    """Send a secret to a directly controlled interactive child such as ssh-add."""
 
     if logging_enabled:
         child.logfile = None
@@ -383,28 +383,6 @@ def ensure_private_agent_identity(
         "Private ssh-agent identity lifetime expired; reloading the configured key before the next dataset."
     )
     add_identity_to_private_agent(session, password, logger)
-
-
-def harden_syncoid_command_for_agent(
-    syncoid_command: list[str],
-    session: SSHAgentSession,
-) -> list[str]:
-    """Force Syncoid SSH to use only the isolated agent key without forwarding."""
-
-    if not syncoid_command:
-        return []
-
-    hardening_options = [
-        "--sshoption=ForwardAgent=no",
-        "--sshoption=StrictHostKeyChecking=yes",
-        "--sshoption=IdentitiesOnly=yes",
-        f"--sshoption=IdentityAgent={session.socket_path}",
-        "--sshoption=AddKeysToAgent=no",
-        "--sshoption=BatchMode=yes",
-        "--sshoption=PreferredAuthentications=publickey",
-    ]
-
-    return [syncoid_command[0], *hardening_options, *syncoid_command[1:]]
 
 
 def stop_private_ssh_agent(
@@ -740,6 +718,9 @@ def ssh_command(
             )
 
         elif index == PATTERN_PASSPHRASE:
+            if run_context.logging_enabled:
+                child.logfile = None
+
             if password is None:
                 die(
                     child,
@@ -748,12 +729,10 @@ def ssh_command(
                     logger=logger,
                 )
 
-            send_secret(
-                child,
-                password,
-                output_handle,
-                run_context.logging_enabled,
-            )
+            child.sendline(password)
+
+            if run_context.logging_enabled:
+                child.logfile = output_handle
 
         elif index == PATTERN_EOF:
             close_child_logfile(child, logger)
@@ -905,6 +884,9 @@ def ssh_command(
             )
 
         elif index == PATTERN_PASSWORD:
+            if run_context.logging_enabled:
+                child.logfile = None
+
             if password is None:
                 die(
                     child,
@@ -913,12 +895,10 @@ def ssh_command(
                     logger=logger,
                 )
 
-            send_secret(
-                child,
-                password,
-                output_handle,
-                run_context.logging_enabled,
-            )
+            child.sendline(password)
+
+            if run_context.logging_enabled:
+                child.logfile = output_handle
 
     close_child_logfile(child, logger)
     return SyncoidAttemptResult(
@@ -959,9 +939,8 @@ def run_replications(
 
         if ssh_agent_session is not None:
             ensure_private_agent_identity(ssh_agent_session, password, logger)
-            syncoid_execute = harden_syncoid_command_for_agent(
-                syncoid_execute,
-                ssh_agent_session,
+            logger.info(
+                "Private ssh-agent identity is loaded; Syncoid will inherit SSH_AUTH_SOCK and keep the configured Syncoid command unchanged."
             )
 
         logger.info(
@@ -978,7 +957,7 @@ def run_replications(
         while True:
             result = ssh_command(
                 current_command,
-                None if ssh_agent_session is not None else password,
+                password,
                 run_context,
                 logger,
                 retry_broken_pipe=app_config.retry_broken_pipe,


### PR DESCRIPTION
…t kept all new functions like private per-run ssh-agent, direct Pexpect → ssh-add, bounded SSH-agent key lifetime and reload, agent cleanup, JSON MQTT success/failure reporting, dedicated mqtt_json_topic, JSON retain = false, old retained MQTT message, old retained HA availability integration, BackupTitle in JSON, no Syncoid command exposed in JSON, stale resumable-stream recovery, Syncoid-owned reset of invalid receive state, the related Broken Pipe handling, configurable ordinary Broken Pipe retries, email/system actions, .gitignore